### PR TITLE
feat: add triggerOnce option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Add `bs-react-is-visible` to `bs-dependencies` in `bsconfig.json`
 
 ## Usage
 
+### Basic
+
 ```reason
 [@react.component]
 let make = () => {
@@ -29,6 +31,21 @@ let make = () => {
 
   <h1 ref>
     {(isVisible ? "I'm visible!" : "I'm not visible") |> React.string}
+  </h1>;
+};
+```
+
+### With options
+
+```reason
+let options: ReactIsVisible.options = {triggerOnce: true};
+
+[@react.component]
+let make = () => {
+  let (isVisible, ref) = ReactIsVisible.useIsVisible(~options, ());
+
+  <h1 ref>
+    {(isVisible ? "I'm triggered as visible once!" : "I'm not visible") |> React.string}
   </h1>;
 };
 ```

--- a/README.md
+++ b/README.md
@@ -38,11 +38,9 @@ let make = () => {
 ### With options
 
 ```reason
-let options: ReactIsVisible.options = {triggerOnce: true};
-
 [@react.component]
 let make = () => {
-  let (isVisible, ref) = ReactIsVisible.useIsVisible(~options, ());
+  let (isVisible, ref) = ReactIsVisible.useIsVisible(~options={once: true}, ());
 
   <h1 ref>
     {(isVisible ? "I'm triggered as visible once!" : "I'm not visible") |> React.string}

--- a/examples/App.re
+++ b/examples/App.re
@@ -64,6 +64,13 @@ let make = () => {
         style={Style.link(active === "lazyload")}>
         {"Lazy Load" |> React.string}
       </a>
+      <a
+        href="#triggeronce"
+        title="TriggerOnce"
+        onClick={_ => setActiveExample(_ => (<TriggerOnce />, "triggeronce"))}
+        style={Style.link(active === "triggeronce")}>
+        {"Trigger Once" |> React.string}
+      </a>
     </nav>
     activeExample
   </div>;

--- a/examples/TriggerOnce.re
+++ b/examples/TriggerOnce.re
@@ -1,0 +1,20 @@
+module Style = {
+  let fixed = ReactDOMRe.Style.make(~position="fixed", ~right="2rem", ());
+};
+
+let options: ReactIsVisible.options = {triggerOnce: true};
+
+[@react.component]
+let make = () => {
+  let (isVisible, ref) = ReactIsVisible.useIsVisible(~options, ());
+
+  <div style=Basic.Style.wrapper>
+    <h1> {"Scroll down" |> React.string} </h1>
+    <h2 style=Style.fixed>
+      {"Was triggered: " ++ string_of_bool(isVisible) ++ "" |> React.string}
+    </h2>
+    <div ref style={Basic.Style.box(isVisible)}>
+      {(isVisible ? "I'm visible!" : "I'm not visible!") |> React.string}
+    </div>
+  </div>;
+};

--- a/examples/TriggerOnce.re
+++ b/examples/TriggerOnce.re
@@ -2,11 +2,10 @@ module Style = {
   let fixed = ReactDOMRe.Style.make(~position="fixed", ~right="2rem", ());
 };
 
-let options: ReactIsVisible.options = {triggerOnce: true};
-
 [@react.component]
 let make = () => {
-  let (isVisible, ref) = ReactIsVisible.useIsVisible(~options, ());
+  let (isVisible, ref) =
+    ReactIsVisible.useIsVisible(~options={once: true}, ());
 
   <div style=Basic.Style.wrapper>
     <h1> {"Scroll down" |> React.string} </h1>

--- a/src/ReactIsVisible.re
+++ b/src/ReactIsVisible.re
@@ -12,19 +12,28 @@ module VO = {
   external getSubscribers: unit => 'subscriberList = "getSubscribers";
 };
 
-let useIsVisible = () => {
+type options = {triggerOnce: bool};
+let defaultOptions = {triggerOnce: false};
+
+let useIsVisible = (~options=defaultOptions, ()) => {
   let (isVisible, setIsVisible) = React.useState(() => false);
   let nodeRef = React.useRef(Js.Nullable.null);
 
   React.useEffect0(() => {
-    let handleVisibilityChange = entry =>
+    let handleVisibilityChange = (el, entry) => {
       setIsVisible(_prevIntersecting => entry##isIntersecting);
+
+      if (entry##isIntersecting && options.triggerOnce) {
+        VO.unwatch(el);
+      };
+    };
 
     let domElement =
       switch (nodeRef |> React.Ref.current |> Js.Nullable.toOption) {
       | Some(el) =>
-        VO.watch(el, handleVisibilityChange);
+        VO.watch(el, entry => handleVisibilityChange(el, entry));
         Some(el);
+
       | None => None
       };
 

--- a/src/ReactIsVisible.re
+++ b/src/ReactIsVisible.re
@@ -12,8 +12,8 @@ module VO = {
   external getSubscribers: unit => 'subscriberList = "getSubscribers";
 };
 
-type options = {triggerOnce: bool};
-let defaultOptions = {triggerOnce: false};
+type options = {once: bool};
+let defaultOptions = {once: false};
 
 let useIsVisible = (~options=defaultOptions, ()) => {
   let (isVisible, setIsVisible) = React.useState(() => false);
@@ -23,7 +23,7 @@ let useIsVisible = (~options=defaultOptions, ()) => {
     let handleVisibilityChange = (el, entry) => {
       setIsVisible(_prevIntersecting => entry##isIntersecting);
 
-      if (entry##isIntersecting && options.triggerOnce) {
+      if (entry##isIntersecting && options.once) {
         VO.unwatch(el);
       };
     };


### PR DESCRIPTION
For me this is a much-used feature for unloading event listeners from elements that were revealed and should stay revealed.

Idea taken from https://github.com/thebuilder/react-intersection-observer

Added an example to the demo as well.